### PR TITLE
フォルダー名変更時のinputタグenterで発火

### DIFF
--- a/src/components/features/PlayListSideBar/index.tsx
+++ b/src/components/features/PlayListSideBar/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { LocalStorageObjects } from '@/types/localstrageObjects';
 import { saveToLocalStorage } from '@/utils/storage';
@@ -70,6 +70,7 @@ const PlayListSideBar = ({
     newName: string
   ) => {
     if (!localStorageObjects) return;
+    if (newName === '') return;
     const newObjects = renameFolder(
       index,
       newName,
@@ -85,6 +86,23 @@ const PlayListSideBar = ({
       localStorageObjects
     );
     setLocalStorageObjects(newObject);
+  };
+
+  const [open, setOpen] = useState<boolean>(false);
+  const [composing, setComposition] =
+    useState<boolean>(false);
+  const startComposition = () => setComposition(true);
+  const endComposition = () => setComposition(false);
+  const handleKeyDown = (
+    e: string,
+    index: number,
+    newName: string
+  ) => {
+    if (e === 'Enter') {
+      if (composing) return;
+      renameFolderHandler(index, newName);
+      setOpen(false);
+    }
   };
 
   return (
@@ -128,7 +146,10 @@ const PlayListSideBar = ({
                     <DotsVerticalIcon className="text-primary" />
                   </MenubarTrigger>
                   <MenubarContent>
-                    <Dialog>
+                    <Dialog
+                      open={open}
+                      onOpenChange={setOpen}
+                    >
                       <DialogTrigger asChild>
                         <Button
                           variant="ghost"
@@ -157,27 +178,27 @@ const PlayListSideBar = ({
                             </Label>
                             <Input
                               id="name"
+                              placeholder='フォルダー名'
                               defaultValue={folder.name}
                               className="col-span-3"
                               ref={inputRenameRef}
-                            />
-                          </div>
-                        </div>
-                        <DialogFooter>
-                          <DialogClose asChild>
-                            <Button
-                              onClick={() =>
-                                renameFolderHandler(
+                              onCompositionStart={
+                                startComposition
+                              }
+                              onCompositionEnd={
+                                endComposition
+                              }
+                              onKeyDown={(event) =>
+                                handleKeyDown(
+                                  event.key,
                                   index,
                                   inputRenameRef.current
                                     ?.value ?? folder.name
                                 )
                               }
-                            >
-                              変更
-                            </Button>
-                          </DialogClose>
-                        </DialogFooter>
+                            />
+                          </div>
+                        </div>
                       </DialogContent>
                     </Dialog>
                     <Dialog>

--- a/src/components/features/PlaylistTitleDialog/index.tsx
+++ b/src/components/features/PlaylistTitleDialog/index.tsx
@@ -2,21 +2,17 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Pencil1Icon } from '@radix-ui/react-icons';
 import { Button } from '@/components/ui/button';
-import {
-  LocalStorageObjects,
-} from '@/types/localstrageObjects';
+import { LocalStorageObjects } from '@/types/localstrageObjects';
 import { renameFolder } from './logics/renameFolder';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 type Props = {
   selectedFolderIndex: number;
@@ -39,6 +35,7 @@ const PlaylistTitleDialog = ({
     newName: string
   ) => {
     if (!localStorageObjects) return;
+    if (newName === '') return;
     const newObjects = renameFolder(
       index,
       newName,
@@ -46,8 +43,25 @@ const PlaylistTitleDialog = ({
     );
     setLocalStorageObjects(newObjects);
   };
+
+  const [open, setOpen] = useState<boolean>(false);
+  const [composing, setComposition] =
+    useState<boolean>(false);
+  const startComposition = () => setComposition(true);
+  const endComposition = () => setComposition(false);
+  const handleKeyDown = (
+    e: string,
+    index: number,
+    newName: string
+  ) => {
+    if (e === 'Enter') {
+      if (composing) return;
+      renameFolderHandler(index, newName);
+      setOpen(false);
+    }
+  };
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           variant="ghost"
@@ -72,27 +86,23 @@ const PlaylistTitleDialog = ({
             </Label>
             <Input
               id="name"
+              placeholder="フォルダー名"
               defaultValue={selectedFolder.name}
               className="col-span-3"
               ref={inputRenameRef}
-            />
-          </div>
-        </div>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button
-              onClick={() =>
-                renameFolderHandler(
+              onCompositionStart={startComposition}
+              onCompositionEnd={endComposition}
+              onKeyDown={(event) =>
+                handleKeyDown(
+                  event.key,
                   selectedFolderIndex,
                   inputRenameRef.current?.value ??
                     selectedFolder.name
                 )
               }
-            >
-              変更
-            </Button>
-          </DialogClose>
-        </DialogFooter>
+            />
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
close #64 

Enterで変更完了しモーダルを閉じる
日本語変換時のEnterは発火させない
変更ボタンの削除

<img width="770" alt="image" src="https://github.com/yoshi-non/scp-log/assets/83369665/8c57c5ef-5cec-4244-b062-7c47637a3475">
