### PR TITLE
ドラッグアンドドロップでファイル位置を変えたときに再生ボタンが押せなくなるバグ対応

### DIFF
--- a/src/components/features/PlayList/index.tsx
+++ b/src/components/features/PlayList/index.tsx
@@ -47,10 +47,6 @@ const PlayList = ({
     useYouTubePlayer();
 
   useEffect(() => {
-    setIsPlaying('BUFFERING');
-  }, [selectedMovieIndex]);
-
-  useEffect(() => {
     setIsReady(false);
   }, [selectedFolderIndex]);
 

--- a/src/components/ui/youtubePlayer.tsx
+++ b/src/components/ui/youtubePlayer.tsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
 import { useYouTubeSupportInited } from '../functions/youtube-provider';
 


### PR DESCRIPTION
close #102 